### PR TITLE
More Error Prevention

### DIFF
--- a/src/main/java/com/google/sps/servlets/CreateExamServlet.java
+++ b/src/main/java/com/google/sps/servlets/CreateExamServlet.java
@@ -43,6 +43,9 @@ public class CreateExamServlet extends HttpServlet {
     //want to create and saves it in the datastore
     Long date = (new Date()).getTime();
     String name = UtilityClass.getParameter(request, "name", "");
+    // Remove all html tags and trim the spaces in the exam name.
+    name = name.replaceAll("\\<.*?\\>", "");
+    name = name.trim();
     String duration = UtilityClass.getParameter(request, "duration", "");
     if (name == "" || duration == "") {
       response.sendError(HttpServletResponse.SC_BAD_REQUEST,

--- a/src/main/java/com/google/sps/servlets/CreateExamServlet.java
+++ b/src/main/java/com/google/sps/servlets/CreateExamServlet.java
@@ -39,7 +39,7 @@ public class CreateExamServlet extends HttpServlet {
   @Override
   public void doPost(final HttpServletRequest request,
       final HttpServletResponse response) throws IOException {
-    //Servlet Recevies information from the client about an exam they
+    //Servlet Receives information from the client about an exam they
     //want to create and saves it in the datastore
     Long date = (new Date()).getTime();
     String name = UtilityClass.getParameter(request, "name", "");

--- a/src/main/java/com/google/sps/servlets/CreateExamServlet.java
+++ b/src/main/java/com/google/sps/servlets/CreateExamServlet.java
@@ -45,15 +45,16 @@ public class CreateExamServlet extends HttpServlet {
     String name = UtilityClass.getParameter(request, "name", "");
     String duration = UtilityClass.getParameter(request, "duration", "");
     if (name == "" || duration == "") {
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+        "You have entered one or more null parameters");
       logger.atWarning().log("One or more null parameters");
       return;
     }
     UserService userService = UserServiceFactory.getUserService();
     if (!userService.isUserLoggedIn()) {
       logger.atWarning().log("User is not logged in.");
-      response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-      response.sendRedirect("/");
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+        "You are not authorised to view this page");
       return;
     }
     logger.atInfo().log("User =%s is logged in", userService.getCurrentUser());
@@ -77,7 +78,8 @@ public class CreateExamServlet extends HttpServlet {
 
     } catch (DatastoreFailureException e) {
       logger.atSevere().log("Error with datastore: %s", e);
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          "Internal Error occurred when trying to create your exam");
       return;
     }
   }

--- a/src/main/java/com/google/sps/servlets/CreateQuestionServlet.java
+++ b/src/main/java/com/google/sps/servlets/CreateQuestionServlet.java
@@ -50,6 +50,9 @@ public class CreateQuestionServlet extends HttpServlet {
     Long date = (new Date()).getTime();
     String testName = UtilityClass.getParameter(request, "testName", "");
     String question = UtilityClass.getParameter(request, "question", "");
+    //Remove all html tags and trim the spaces in the questions.
+    question = question.replaceAll("\\<.*?\\>", "");
+    question = question.trim();
     String marks = UtilityClass.getParameter(request, "marks", "");
 
     if (testName == "" || question == "" || marks == "") {

--- a/src/main/java/com/google/sps/servlets/CreateQuestionServlet.java
+++ b/src/main/java/com/google/sps/servlets/CreateQuestionServlet.java
@@ -53,7 +53,8 @@ public class CreateQuestionServlet extends HttpServlet {
     String marks = UtilityClass.getParameter(request, "marks", "");
 
     if (testName == "" || question == "" || marks == "") {
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+          "You have entered one or more null parameters");
       logger.atWarning().log("One or more null parameters");
       return;
     }
@@ -61,7 +62,8 @@ public class CreateQuestionServlet extends HttpServlet {
     UserService userService = UserServiceFactory.getUserService();
     if (!userService.isUserLoggedIn()) {
       logger.atWarning().log("User is not logged in.");
-      response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+          "You are not authorised to view this page");
       return;
     }
     logger.atInfo().log("user=%s is logged in", userService.getCurrentUser());
@@ -85,7 +87,8 @@ public class CreateQuestionServlet extends HttpServlet {
     } catch (DatastoreFailureException e) {
         logger.atSevere().log("Datastore Failure.Datastore is not responding:"
           + " %s", e);
-        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+            "Internal Error occurred when trying to create your question");
         return;
     }
   }

--- a/src/main/java/com/google/sps/servlets/ExamsUserOwnsServlet.java
+++ b/src/main/java/com/google/sps/servlets/ExamsUserOwnsServlet.java
@@ -48,7 +48,8 @@ public class ExamsUserOwnsServlet extends HttpServlet{
     UserService userService = UserServiceFactory.getUserService();
     if (!userService.isUserLoggedIn()) {
       logger.atWarning().log("User is not logged in.");
-      response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+          "You are not authorised to view this page");
       return;
     }
     String ownerID = userService.getCurrentUser().getEmail(); 
@@ -74,9 +75,10 @@ public class ExamsUserOwnsServlet extends HttpServlet{
       response.sendRedirect("/createExam.html");
       response.getWriter().println(UtilityClass.convertToJson(examList));
     } catch (DatastoreFailureException e) {
-        logger.atSevere().log("Datastore error:%s" ,e);
-        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        return;
+      logger.atSevere().log("Datastore error:%s" ,e);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          "Internal Error occurred when trying to retrieve your exams");
+      return;
     }
   }
 }

--- a/src/main/java/com/google/sps/servlets/QuestionFormServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionFormServlet.java
@@ -81,10 +81,10 @@ public class QuestionFormServlet extends HttpServlet {
     out.println("<form id=\"createQuestion\" action=\"/createQuestion\""
         + " method=\"POST\">");
     out.println("<label for=\"question\">Enter Question:</label><br>");
-    out.println("<textarea name=\"question\" rows=\"4\" cols=\"50\" required>"
+    out.println("<textarea name=\"question\" rows=\"4\" cols=\"50\" maxlength=\"200\"required>"
         + "</textarea><br>");
     out.println("<label for=\"marks\">Marks given for Question:</label><br>");
-    out.println("<input type=\"number\" id=\"marks\" name=\"marks\" required>");
+    out.println("<input type=\"number\" id=\"marks\" name=\"marks\" min=\"0\"max=\"1000\" step=\"0.1\"required>");
     out.println("<h3> Select which test you want the questions added to</h1>");
     out.println("<select name=\"testName\">");
     // Find all tests created by this user and display them as a dropdown menu.

--- a/src/main/java/com/google/sps/servlets/QuestionFormServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionFormServlet.java
@@ -102,6 +102,7 @@ public class QuestionFormServlet extends HttpServlet {
       logger.atWarning().log("There was a problem with retrieving the exams %s",
           e);
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      return;
     }
 
     out.println("</select>");

--- a/src/main/java/com/google/sps/servlets/QuestionFormServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionFormServlet.java
@@ -84,7 +84,7 @@ public class QuestionFormServlet extends HttpServlet {
     out.println("<textarea name=\"question\" rows=\"4\" cols=\"50\" maxlength=\"200\"required>"
         + "</textarea><br>");
     out.println("<label for=\"marks\">Marks given for Question:</label><br>");
-    out.println("<input type=\"number\" id=\"marks\" name=\"marks\" min=\"0\"max=\"1000\" step=\"0.1\"required>");
+    out.println("<input type=\"number\" id=\"marks\" name=\"marks\" min=\"0\"max=\"1000\" step=\"0.01\"required>");
     out.println("<h3> Select which test you want the questions added to</h1>");
     out.println("<select name=\"testName\">");
     // Find all tests created by this user and display them as a dropdown menu.

--- a/src/main/java/com/google/sps/servlets/QuestionFormServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionFormServlet.java
@@ -48,8 +48,8 @@ public class QuestionFormServlet extends HttpServlet {
     UserService userService = UserServiceFactory.getUserService();
     if (!userService.isUserLoggedIn()) {
       logger.atWarning().log("User is not logged in.");
-      response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-      response.sendRedirect("/");
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+        "You are not authorised to view this page");
       return;
     }
     logger.atInfo().log("User=%s is logged in", userService.getCurrentUser());
@@ -101,7 +101,8 @@ public class QuestionFormServlet extends HttpServlet {
     } catch (Exception e) {
       logger.atWarning().log("There was a problem with retrieving the exams %s",
           e);
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          "Internal Error occurred when trying to find your tests");
       return;
     }
 

--- a/src/main/java/com/google/sps/servlets/QuestionsUserOwnsServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionsUserOwnsServlet.java
@@ -96,10 +96,9 @@ public class QuestionsUserOwnsServlet extends HttpServlet {
       for (Entity entity : results.asIterable()) {
         long questionId = entity.getKey().getId();
         String question = (String) entity.getProperty("question");
-        String plainQuestion = question.replaceAll("\\<.*?\\>", "");
         String marks = (String) entity.getProperty("marks");
         out.println("<input onclick=\"checkBox()\" id=\"checkbox\" type=\"checkbox\" name=\"question\" value=\""
-          + String.valueOf(questionId) + "\">" + plainQuestion
+          + String.valueOf(questionId) + "\">" + question
           + " (" + marks + ")<br>");
       }
     } catch (DatastoreFailureException e) {
@@ -124,7 +123,6 @@ public class QuestionsUserOwnsServlet extends HttpServlet {
       for (Entity entity : listExams.asIterable()) {
         long examID = entity.getKey().getId();
         String name = (String) entity.getProperty("name");
-        name = name.replaceAll("\\<.*?\\>", "");
         out.println("<option>" + name  + "</option>");
       }
     } catch (DatastoreFailureException e) {

--- a/src/main/java/com/google/sps/servlets/QuestionsUserOwnsServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionsUserOwnsServlet.java
@@ -97,7 +97,7 @@ public class QuestionsUserOwnsServlet extends HttpServlet {
         long questionId = entity.getKey().getId();
         String question = (String) entity.getProperty("question");
         String marks = (String) entity.getProperty("marks");
-        out.println("<input type=\"checkbox\" name=\"question\" value=\""
+        out.println("<input onclick=\"checkBox()\" id=\"checkbox\" type=\"checkbox\" name=\"question\" value=\""
           + String.valueOf(questionId) + "\">" + question
           + " (" + marks + ")<br>");
       }
@@ -134,7 +134,7 @@ public class QuestionsUserOwnsServlet extends HttpServlet {
     out.println("</select>");
     out.println("<br/>");
     out.println("<br/>");
-    out.println("<button>Submit</button>");
+    out.println("<button style=\"display: none;\" id=\"checkBoxSubmit\">Submit</button>");
     out.println("</form>");
     out.println("</body>");
     logger.atInfo().log("Questions and Tests that the User: %s , owns were found"

--- a/src/main/java/com/google/sps/servlets/QuestionsUserOwnsServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionsUserOwnsServlet.java
@@ -96,9 +96,10 @@ public class QuestionsUserOwnsServlet extends HttpServlet {
       for (Entity entity : results.asIterable()) {
         long questionId = entity.getKey().getId();
         String question = (String) entity.getProperty("question");
+        String plainQuestion = question.replaceAll("\\<.*?\\>", "");
         String marks = (String) entity.getProperty("marks");
         out.println("<input onclick=\"checkBox()\" id=\"checkbox\" type=\"checkbox\" name=\"question\" value=\""
-          + String.valueOf(questionId) + "\">" + question
+          + String.valueOf(questionId) + "\">" + plainQuestion
           + " (" + marks + ")<br>");
       }
     } catch (DatastoreFailureException e) {

--- a/src/main/java/com/google/sps/servlets/QuestionsUserOwnsServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionsUserOwnsServlet.java
@@ -48,8 +48,8 @@ public class QuestionsUserOwnsServlet extends HttpServlet {
     UserService userService = UserServiceFactory.getUserService();
     if (!userService.isUserLoggedIn()) {
       logger.atWarning().log("User is not logged in.");
-      response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-      response.sendRedirect("/");
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+          "You are not authorised to view this page");
       return;
     }
     logger.atInfo().log("user=%s", userService.getCurrentUser());
@@ -104,7 +104,8 @@ public class QuestionsUserOwnsServlet extends HttpServlet {
     } catch (DatastoreFailureException e) {
       logger.atWarning().log("There was an error with retrieving the questions: %s",
           e);
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          "Internal Error occurred when trying to retrieve your questions");
       return;
     }
 
@@ -127,7 +128,8 @@ public class QuestionsUserOwnsServlet extends HttpServlet {
     } catch (DatastoreFailureException e) {
       logger.atWarning().log("There was an error when retrieving the tests: %s",
           e);
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          "Internal Error occurred when trying to retrieve your Tests");
       return;
     }
 

--- a/src/main/java/com/google/sps/servlets/QuestionsUserOwnsServlet.java
+++ b/src/main/java/com/google/sps/servlets/QuestionsUserOwnsServlet.java
@@ -124,6 +124,7 @@ public class QuestionsUserOwnsServlet extends HttpServlet {
       for (Entity entity : listExams.asIterable()) {
         long examID = entity.getKey().getId();
         String name = (String) entity.getProperty("name");
+        name = name.replaceAll("\\<.*?\\>", "");
         out.println("<option>" + name  + "</option>");
       }
     } catch (DatastoreFailureException e) {

--- a/src/main/java/com/google/sps/servlets/SaveQuestionsFromBankServlet.java
+++ b/src/main/java/com/google/sps/servlets/SaveQuestionsFromBankServlet.java
@@ -50,8 +50,8 @@ public class SaveQuestionsFromBankServlet extends HttpServlet {
     UserService userService = UserServiceFactory.getUserService();
     if (!userService.isUserLoggedIn()) {
       logger.atWarning().log("User is not logged in.");
-      response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-      response.sendRedirect("/");
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+          "You are not authorised to view this page");
       return;
     }
     logger.atInfo().log("user=%s is logged in", userService.getCurrentUser());
@@ -74,7 +74,8 @@ public class SaveQuestionsFromBankServlet extends HttpServlet {
     } catch (Exception e) {
       logger.atSevere().log("There was an error with saving the questions"
         + " : %s", e);
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          "Internal Error occurred when trying to save your questions to the test");
       return;
     }
 

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -91,6 +91,23 @@ function newUser(name) {
     return 'dashboard.html';
   }
 };
+
+/**
+ * If user has not checked a box do not show
+ * the submit button.
+ */
+function checkBox() {
+  const checkBoxList = document.querySelectorAll("#checkbox");
+  const submitButton = document.getElementById("checkBoxSubmit");
+  const checkBoxArray = [...checkBoxList];
+  const areTheyChecked = checkBoxArray.some(box => box.checked );
+  console.log(areTheyChecked);
+  if(areTheyChecked === true){
+    submitButton.style.display = "block";
+  } else if (areTheyChecked === false) {
+    submitButton.style.display = "none"; 
+  }
+};
 /* eslint-enable no-unused-vars */
 
 // On load

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -97,15 +97,15 @@ function newUser(name) {
  * the submit button.
  */
 function checkBox() {
-  const checkBoxList = document.querySelectorAll("#checkbox");
-  const submitButton = document.getElementById("checkBoxSubmit");
+  const checkBoxList = document.querySelectorAll('#checkbox');
+  const submitButton = document.getElementById('checkBoxSubmit');
   const checkBoxArray = [...checkBoxList];
-  const areTheyChecked = checkBoxArray.some(box => box.checked );
+  const areTheyChecked = checkBoxArray.some((box) => box.checked );
   console.log(areTheyChecked);
-  if(areTheyChecked === true) {
-    submitButton.style.display = "block";
+  if (areTheyChecked === true) {
+    submitButton.style.display = 'block';
   } else {
-    submitButton.style.display = "none"; 
+    submitButton.style.display = 'none';
   }
 };
 /* eslint-enable no-unused-vars */

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -102,9 +102,9 @@ function checkBox() {
   const checkBoxArray = [...checkBoxList];
   const areTheyChecked = checkBoxArray.some(box => box.checked );
   console.log(areTheyChecked);
-  if(areTheyChecked === true){
+  if(areTheyChecked === true) {
     submitButton.style.display = "block";
-  } else if (areTheyChecked === false) {
+  } else {
     submitButton.style.display = "none"; 
   }
 };

--- a/src/test/java/com/google/sps/CreateExamServletTest.java
+++ b/src/test/java/com/google/sps/CreateExamServletTest.java
@@ -96,7 +96,7 @@ public final class CreateExamServletTest extends CreateExamServlet {
     CreateExamServlet servlet = new CreateExamServlet();
     servlet.doPost(request, response);
     verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST,
-      "You have entered one or more null parameters");
+        "You have entered one or more null parameters");
   }
 
   @Test
@@ -116,7 +116,7 @@ public final class CreateExamServletTest extends CreateExamServlet {
     CreateExamServlet servlet = new CreateExamServlet();
     servlet.doPost(request, response);
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
-      "You are not authorised to view this page");
+        "You are not authorised to view this page");
   }
   private void helperLogin() {
     /* Login user with email "test@example.com" */

--- a/src/test/java/com/google/sps/CreateExamServletTest.java
+++ b/src/test/java/com/google/sps/CreateExamServletTest.java
@@ -95,7 +95,8 @@ public final class CreateExamServletTest extends CreateExamServlet {
 
     CreateExamServlet servlet = new CreateExamServlet();
     servlet.doPost(request, response);
-    verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST);
+    verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST,
+      "You have entered one or more null parameters");
   }
 
   @Test
@@ -114,7 +115,8 @@ public final class CreateExamServletTest extends CreateExamServlet {
 
     CreateExamServlet servlet = new CreateExamServlet();
     servlet.doPost(request, response);
-    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
+      "You are not authorised to view this page");
   }
   private void helperLogin() {
     /* Login user with email "test@example.com" */

--- a/src/test/java/com/google/sps/CreateQuestionServletTest.java
+++ b/src/test/java/com/google/sps/CreateQuestionServletTest.java
@@ -123,7 +123,7 @@ public final class CreateQuestionServletTest extends CreateQuestionServlet {
     CreateQuestionServlet servlet = new CreateQuestionServlet();
     servlet.doPost(request, response);
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
-      "You are not authorised to view this page");
+        "You are not authorised to view this page");
   }
   private void helperLogin() {
     /* Login user with email "test@example.com" */

--- a/src/test/java/com/google/sps/CreateQuestionServletTest.java
+++ b/src/test/java/com/google/sps/CreateQuestionServletTest.java
@@ -102,7 +102,8 @@ public final class CreateQuestionServletTest extends CreateQuestionServlet {
     
     CreateQuestionServlet servlet = new CreateQuestionServlet();
     servlet.doPost(request, response);
-    verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST);
+    verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST,
+        "You have entered one or more null parameters");
   }
 
   @Test
@@ -121,7 +122,8 @@ public final class CreateQuestionServletTest extends CreateQuestionServlet {
     when(request.getParameter("testName")).thenReturn("Trial");
     CreateQuestionServlet servlet = new CreateQuestionServlet();
     servlet.doPost(request, response);
-    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
+      "You are not authorised to view this page");
   }
   private void helperLogin() {
     /* Login user with email "test@example.com" */

--- a/src/test/java/com/google/sps/ExamsUserOwnsServletTest.java
+++ b/src/test/java/com/google/sps/ExamsUserOwnsServletTest.java
@@ -118,7 +118,7 @@ public final class ExamsUserOwnsServletTest extends ExamsUserOwnsServlet {
     ExamsUserOwnsServlet servlet= new ExamsUserOwnsServlet();
     servlet.doGet(request, response);
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
-      "You are not authorised to view this page");
+        "You are not authorised to view this page");
   }
   private void helperLogin() {
     /* Login user with email "test@example.com" */

--- a/src/test/java/com/google/sps/ExamsUserOwnsServletTest.java
+++ b/src/test/java/com/google/sps/ExamsUserOwnsServletTest.java
@@ -117,7 +117,8 @@ public final class ExamsUserOwnsServletTest extends ExamsUserOwnsServlet {
     
     ExamsUserOwnsServlet servlet= new ExamsUserOwnsServlet();
     servlet.doGet(request, response);
-    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
+      "You are not authorised to view this page");
   }
   private void helperLogin() {
     /* Login user with email "test@example.com" */

--- a/src/test/java/com/google/sps/QuestionFormServletTest.java
+++ b/src/test/java/com/google/sps/QuestionFormServletTest.java
@@ -89,7 +89,7 @@ public final class QuestionFormServletTest extends QuestionFormServlet {
     QuestionFormServlet servlet= new QuestionFormServlet();
     servlet.doGet(request, response);
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
-      "You are not authorised to view this page");
+        "You are not authorised to view this page");
   }
   private void helperLogin() {
     /* Login user with email "test@example.com" */

--- a/src/test/java/com/google/sps/QuestionFormServletTest.java
+++ b/src/test/java/com/google/sps/QuestionFormServletTest.java
@@ -88,7 +88,8 @@ public final class QuestionFormServletTest extends QuestionFormServlet {
     
     QuestionFormServlet servlet= new QuestionFormServlet();
     servlet.doGet(request, response);
-    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
+      "You are not authorised to view this page");
   }
   private void helperLogin() {
     /* Login user with email "test@example.com" */

--- a/src/test/java/com/google/sps/QuestionsUserOwnsServletTest.java
+++ b/src/test/java/com/google/sps/QuestionsUserOwnsServletTest.java
@@ -92,7 +92,8 @@ public final class QuestionsUserOwnsServletTest extends QuestionsUserOwnsServlet
     
     QuestionsUserOwnsServlet servlet= new QuestionsUserOwnsServlet();
     servlet.doGet(request, response);
-    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
+      "You are not authorised to view this page");
   }
   private void setFakeQuestions () {
     /*Set up two fake question entities for testing purposes */

--- a/src/test/java/com/google/sps/QuestionsUserOwnsServletTest.java
+++ b/src/test/java/com/google/sps/QuestionsUserOwnsServletTest.java
@@ -93,7 +93,7 @@ public final class QuestionsUserOwnsServletTest extends QuestionsUserOwnsServlet
     QuestionsUserOwnsServlet servlet= new QuestionsUserOwnsServlet();
     servlet.doGet(request, response);
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
-      "You are not authorised to view this page");
+        "You are not authorised to view this page");
   }
   private void setFakeQuestions () {
     /*Set up two fake question entities for testing purposes */

--- a/src/test/java/com/google/sps/SaveQuestionsFromBankServletTest.java
+++ b/src/test/java/com/google/sps/SaveQuestionsFromBankServletTest.java
@@ -122,7 +122,8 @@ public final class SaveQuestionsFromBankServletTest extends SaveQuestionsFromBan
     
     SaveQuestionsFromBankServlet servlet = new SaveQuestionsFromBankServlet();
     servlet.doPost(request, response);
-    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
+      "You are not authorised to view this page");
   }
   private void helperLogin() {
     /* Login user with email "test@example.com" */

--- a/src/test/java/com/google/sps/SaveQuestionsFromBankServletTest.java
+++ b/src/test/java/com/google/sps/SaveQuestionsFromBankServletTest.java
@@ -123,7 +123,7 @@ public final class SaveQuestionsFromBankServletTest extends SaveQuestionsFromBan
     SaveQuestionsFromBankServlet servlet = new SaveQuestionsFromBankServlet();
     servlet.doPost(request, response);
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED,
-      "You are not authorised to view this page");
+        "You are not authorised to view this page");
   }
   private void helperLogin() {
     /* Login user with email "test@example.com" */


### PR DESCRIPTION
With sendError responses I have added a message to make it clearer to the user why this error occurred.
Set max length for the amount of characters in the question and in the marks, this should stop accidental or on purpose overflow.
When saving a test/question remove all html tags in order to secure our website
Trim test names and questions as if there is a space before a name of a test or question it does not get saved properly in the datastore